### PR TITLE
Force metacache to only use 1 CPUs as not multithreaded

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -2,7 +2,7 @@ lint:
   files_exist:
     - conf/igenomes.config
     - conf/igenomes_ignored.config
-nf_core_version: 3.5.1
+nf_core_version: 3.5.2
 repository_type: pipeline
 template:
   author: James A. Fellows Yates and the nf-core community

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#158](https://github.com/nf-core/createtaxdb/pull/158) Prevent sylph failing due to too long commands when many input genomes (by @softstam, @jfy133)
 - [#160](https://github.com/nf-core/createtaxdb/pull/160) Prevent sourmash failing due to too long commands when many input genomes (by @softstam, @jfy133)
+- [#161](https://github.com/nf-core/createtaxdb/pull/161) Force METACACHE_BUILD module to always use one CPU, as not multithreaded, removing warning (by @jfy133)
 
 ### `Dependencies`
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -64,4 +64,7 @@ process {
     withName: KRAKEN2_BUILD {
         label = 'process_high'
     }
+    withName: METACACHE_BUILD {
+        cpus = 1
+    }
 }


### PR DESCRIPTION
Close #156 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/createtaxdb/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/createtaxdb _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
