### PR TITLE
Force use KrakenUniq `--jellyfish-bin` and force default use of KMCP --by-seq for more stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- [#165](https://github.com/nf-core/createtaxdb/pull/165) Set defualt use of KMCP `--by-seq` with option to turn off, to reduce memory usage (by @jfy133)
+
 ### `Fixed`
 
 - [#158](https://github.com/nf-core/createtaxdb/pull/158) Prevent sylph failing due to too long commands when many input genomes (by @softstam, @jfy133)
@@ -14,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#161](https://github.com/nf-core/createtaxdb/pull/161) Force METACACHE_BUILD module to always use one CPU, as not multi-threaded, removing warning (by @jfy133)
 - [#162](https://github.com/nf-core/createtaxdb/pull/162) Fix links to FAQ in parameter docs (by @jfy133)
 - [#163](https://github.com/nf-core/createtaxdb/pull/163) Fix code block title in auxiliary files section of FAQ (by @jfy133)
+- [#165](https://github.com/nf-core/createtaxdb/pull/165) Force use of KrakenUniq `--jellyfish-bin` to ensure more regular execution (by @jfy133)
 
 ### `Dependencies`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -108,7 +108,7 @@ process {
 
     withName: KRAKENUNIQ_BUILD {
         ext.prefix = { "${meta.id}-krakenuniq" }
-        ext.args   = { "${params.krakenuniq_build_options}" }
+        ext.args   = { "${params.krakenuniq_build_options}" + " --jellyfish-bin \"\$(which jellyfish)\"" }
     }
 
     withName: MALT_BUILD {
@@ -119,7 +119,10 @@ process {
 
     withName: KMCP_COMPUTE {
         ext.prefix = { "${meta.id}-kmcp-compute" }
-        ext.args   = { "${params.kmcp_compute_options}" }
+        ext.args   = [
+            "${params.kmcp_compute_options}",
+            params.kmcp_compute_byfile ? "" : "--by-seq",
+        ].join(' ').trim()
         publishDir = [
             enabled: false
         ]

--- a/conf/test.config
+++ b/conf/test.config
@@ -37,6 +37,7 @@ params {
     build_kraken2                    = true
     build_krakenuniq                 = true
     build_kmcp                       = true
+    kmcp_compute_byfile              = true
     build_sourmash_dna               = true
     build_sourmash_protein           = true
     build_sylph                      = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -86,6 +86,7 @@ params {
     krakenuniq_build_options         = ''
     malt_build_options               = "--sequenceType DNA"
     kmcp_compute_options             = ''
+    kmcp_compute_byfile              = false
     kmcp_index_options               = ''
     sourmash_build_dna_options       = "--param-string 'scaled=1000,k=31,noabund'"
     sourmash_build_protein_options   = "--param-string 'scaled=200,k=10,noabund'"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -217,6 +217,11 @@
                     "help_text": "See [KMCP documentation](https://bioinf.shenwei.me/kmcp/usage/#compute).",
                     "fa_icon": "fas fa-users-cog"
                 },
+                "kmcp_compute_byfile": {
+                    "type": "boolean",
+                    "description": "Specify to use build k-mer sketch for whole file rather than per sequence.",
+                    "help_text": "By default, nf-core/createtaxdb will pass a concatenation of all input FASTA files to KMCP, with the assumption of each FASTA entry representing a separate genome sequence, utilising the `--by-seq` parameter.\n\nIf you supply a single FASTA pre-concenteated file, specify this to remove the `--by-seq` option from the KMCP compute command.\n\n> Modify(s) tool parameters:\n>   - kmcp compute: `--by-seq`"
+                },
                 "kmcp_index_options": {
                     "type": "string",
                     "description": "Specify parameters being given to kmcp index. Parameters must be supplied in quotes: `--<tool>_build_options \"--your_param\"`.",
@@ -247,7 +252,7 @@
                 "krakenuniq_build_options": {
                     "type": "string",
                     "description": "Specify parameters being given to krakenuniq build. Parameters must be supplied in quotes: `--<tool>_build_options \"--your_param\"`.",
-                    "help_text": "See [KrakenUniq documentation](https://github.com/fbreitwieser/krakenuniq?tab=readme-ov-file#database-building).",
+                    "help_text": "Note: the `--jellyfish-bin` is already specified in the pipeline, it is not necessary to supply this here. See [KrakenUniq documentation](https://github.com/fbreitwieser/krakenuniq?tab=readme-ov-file#database-building).",
                     "fa_icon": "fas fa-users-cog"
                 },
                 "krakenuniq_keepintermediate": {


### PR DESCRIPTION
- KrakenUniq will often fail in conda/container contexts without this parameter
- KMCP will use an insane amount of memory if it thinks the _file_ (not each sequence within) is one massive genome of a single taxon, so we force `--by-seq` as the more common pattern, with option to turn off

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/createtaxdb/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/createtaxdb _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
