### PR TITLE
Fix bracken database name being flipped in samplesheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#162](https://github.com/nf-core/createtaxdb/pull/162) Fix links to FAQ in parameter docs (by @jfy133)
 - [#163](https://github.com/nf-core/createtaxdb/pull/163) Fix code block title in auxiliary files section of FAQ (by @jfy133)
 - [#165](https://github.com/nf-core/createtaxdb/pull/165) Force use of KrakenUniq `--jellyfish-bin` to ensure more regular execution (by @jfy133)
+- [#172](https://github.com/nf-core/createtaxdb/pull/172) Fix generated downstream samplesheet's Bracken directory name being flipped (by @jfy133)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#162](https://github.com/nf-core/createtaxdb/pull/162) Fix links to FAQ in parameter docs (by @jfy133)
 - [#163](https://github.com/nf-core/createtaxdb/pull/163) Fix code block title in auxiliary files section of FAQ (by @jfy133)
 - [#165](https://github.com/nf-core/createtaxdb/pull/165) Force use of KrakenUniq `--jellyfish-bin` to ensure more regular execution (by @jfy133)
-- [#172](https://github.com/nf-core/createtaxdb/pull/172) Fix generated downstream samplesheet's Bracken directory name being flipped (by @jfy133)
+- [#173](https://github.com/nf-core/createtaxdb/pull/173) Fix generated downstream samplesheet's Bracken directory name being flipped (by @jfy133)
 
 ### `Dependencies`
 

--- a/subworkflows/local/generate_downstream_samplesheets/main.nf
+++ b/subworkflows/local/generate_downstream_samplesheets/main.nf
@@ -14,7 +14,7 @@ workflow SAMPLESHEET_TAXPROFILER {
 
         // If the database consists of multiple files, give the parent directory name
         // If database is directory or single file, just give that directory/file name
-        def db_output_name = db instanceof List ? "" : db.getName()
+        def db_output_name = meta.tool == 'bracken' ? "${params.dbname}-bracken" : db instanceof List ? "" : db.getName()
 
         def tool = meta.tool
         def db_name = meta.id + '-' + meta.tool


### PR DESCRIPTION
The database name is hardcoded in the module, but we publish/saveAs it with the correct name.

This ensures the path in the samplesheet is the same as in the `--outdir`

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/createtaxdb/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/createtaxdb _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
