### PR TITLE
Fix metacache receiving wrong taxonomy file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#162](https://github.com/nf-core/createtaxdb/pull/162) Fix links to FAQ in parameter docs (by @jfy133)
 - [#163](https://github.com/nf-core/createtaxdb/pull/163) Fix code block title in auxiliary files section of FAQ (by @jfy133)
 - [#165](https://github.com/nf-core/createtaxdb/pull/165) Force use of KrakenUniq `--jellyfish-bin` to ensure more regular execution (by @jfy133)
-- [#174](https://github.com/nf-core/createtaxdb/pull/174) Fix metacache recieving wrong taxonomy file (was seq2map, should have been accession2taxid) (by @sofstam, @jfy133)
+- [#175](https://github.com/nf-core/createtaxdb/pull/175) Fix metacache recieving wrong taxonomy file (was seq2map, should have been accession2taxid) (by @sofstam, @jfy133)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#162](https://github.com/nf-core/createtaxdb/pull/162) Fix links to FAQ in parameter docs (by @jfy133)
 - [#163](https://github.com/nf-core/createtaxdb/pull/163) Fix code block title in auxiliary files section of FAQ (by @jfy133)
 - [#165](https://github.com/nf-core/createtaxdb/pull/165) Force use of KrakenUniq `--jellyfish-bin` to ensure more regular execution (by @jfy133)
+- [#174](https://github.com/nf-core/createtaxdb/pull/174) Fix metacache recieving wrong taxonomy file (was seq2map, should have been accession2taxid) (by @sofstam, @jfy133)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#162](https://github.com/nf-core/createtaxdb/pull/162) Fix links to FAQ in parameter docs (by @jfy133)
 - [#163](https://github.com/nf-core/createtaxdb/pull/163) Fix code block title in auxiliary files section of FAQ (by @jfy133)
 - [#165](https://github.com/nf-core/createtaxdb/pull/165) Force use of KrakenUniq `--jellyfish-bin` to ensure more regular execution (by @jfy133)
-- [#175](https://github.com/nf-core/createtaxdb/pull/175) Fix metacache recieving wrong taxonomy file (was seq2map, should have been accession2taxid) (by @sofstam, @jfy133)
+- [#175](https://github.com/nf-core/createtaxdb/pull/175) Fix metacache receiving wrong taxonomy file (was seq2map, should have been accession2taxid) (by @sofstam, @jfy133)
 
 ### `Dependencies`
 

--- a/workflows/createtaxdb.nf
+++ b/workflows/createtaxdb.nf
@@ -260,7 +260,7 @@ workflow CREATETAXDB {
         METACACHE_BUILD(
             PREPROCESSING.out.grouped_dna_fastas,
             [file_taxonomy_namesdmp, file_taxonomy_nodesdmp],
-            [file_nucl2taxid],
+            [file_accession2taxid],
         )
         ch_versions = ch_versions.mix(METACACHE_BUILD.out.versions)
         // Current module emits the two file as separate elements of the same tuple, so we need to combine them here


### PR DESCRIPTION
Thanks to @sofstam for noticiting this!

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/createtaxdb/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/createtaxdb _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
